### PR TITLE
Fixed how we read profile yaml file in client

### DIFF
--- a/client/config.go
+++ b/client/config.go
@@ -56,15 +56,14 @@ func fileExists(filePath string) bool {
 	return true
 }
 
-func NewClientConfig(profileConfigPath string) (*Config, error) {
-	cfg := Config{Headers: http.Header{}}
+func NewClientConfig(profileConfigPath string, cfg *Config) (*Config, error) {
 	filePath := parsePath(profileConfigPath)
 
 	if !fileExists(filePath) {
 		if profileConfigPath != "" {
 			return nil, errors.New("profile config file not found")
 		}
-		return &cfg, nil
+		return cfg, nil
 	}
 
 	data, err := os.ReadFile(filePath)
@@ -86,5 +85,5 @@ func NewClientConfig(profileConfigPath string) (*Config, error) {
 		cfg.KeepAlive = 25 * time.Second
 	}
 
-	return &cfg, nil
+	return cfg, nil
 }

--- a/client/config_test.go
+++ b/client/config_test.go
@@ -50,8 +50,8 @@ verbose: true
 
 	configFile := createTempFile(t, sampleConfig)
 	defer os.Remove(configFile)
-
-	cfg, err := NewClientConfig(configFile)
+	cfg := &Config{Headers: http.Header{}}
+	cfg, err := NewClientConfig(configFile, cfg)
 	if err != nil {
 		t.Fatalf("Failed to load config: %v", err)
 	}
@@ -124,8 +124,8 @@ verbose: true
 
 	configFile := createTempFile(t, sampleConfig)
 	defer os.Remove(configFile)
-
-	cfg, err := NewClientConfig(configFile)
+	cfg := &Config{Headers: http.Header{}}
+	cfg, err := NewClientConfig(configFile, cfg)
 	if err != nil {
 		t.Fatalf("Failed to load config: %v", err)
 	}
@@ -141,14 +141,16 @@ verbose: true
 }
 
 func TestNewClientConfig_FileNotFound(t *testing.T) {
-	_, err := NewClientConfig("nonexistent.yaml")
+	cfg := &Config{Headers: http.Header{}}
+	_, err := NewClientConfig("nonexistent.yaml", cfg)
 	if err == nil {
 		t.Fatal("Expected error when loading nonexistent config file, got nil")
 	}
 }
 
 func TestNewClientConfig_DefaultValues(t *testing.T) {
-	_, err := NewClientConfig("")
+	cfg := &Config{Headers: http.Header{}}
+	_, err := NewClientConfig("", cfg)
 	if err != nil {
 		t.Fatalf("Failed to load default config: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -392,27 +392,27 @@ func client(args []string) {
 
 	config := &chclient.Config{Headers: http.Header{}}
 	profilePath := flags.String("profile", "", "")
-	flags.StringVar(&config.Fingerprint, "fingerprint", config.Fingerprint, "")
-	flags.StringVar(&config.Auth, "auth", config.Auth, "")
-	flags.DurationVar(&config.KeepAlive, "keepalive", config.KeepAlive, "")
-	flags.IntVar(&config.MaxRetryCount, "max-retry-count", config.MaxRetryCount, "")
-	flags.DurationVar(&config.MaxRetryInterval, "max-retry-interval", config.MaxRetryInterval, "")
-	flags.StringVar(&config.Proxy, "proxy", config.Proxy, "")
-	flags.StringVar(&config.TLS.CA, "tls-ca", config.TLS.CA, "")
-	flags.BoolVar(&config.TLS.SkipVerify, "tls-skip-verify", config.TLS.SkipVerify, "")
-	flags.StringVar(&config.TLS.Cert, "tls-cert", config.TLS.Cert, "")
-	flags.StringVar(&config.TLS.Key, "tls-key", config.TLS.Key, "")
+	flags.StringVar(&config.Fingerprint, "fingerprint", "", "")
+	flags.StringVar(&config.Auth, "auth", "", "")
+	flags.DurationVar(&config.KeepAlive, "keepalive", 25*time.Second, "")
+	flags.IntVar(&config.MaxRetryCount, "max-retry-count", -1, "")
+	flags.DurationVar(&config.MaxRetryInterval, "max-retry-interval", 0, "")
+	flags.StringVar(&config.Proxy, "proxy", "", "")
+	flags.StringVar(&config.TLS.CA, "tls-ca", "", "")
+	flags.BoolVar(&config.TLS.SkipVerify, "tls-skip-verify", false, "")
+	flags.StringVar(&config.TLS.Cert, "tls-cert", "", "")
+	flags.StringVar(&config.TLS.Key, "tls-key", "", "")
 	//flags.Var(&headerFlags{config.Headers}, "header", "")
 	hostname := flags.String("hostname", "", "")
 	sni := flags.String("sni", "", "")
 	pid := flags.Bool("pid", false, "")
-	verbose := flags.Bool("v", config.Verbose, "")
+	verbose := flags.Bool("v", false, "")
 	flags.Usage = func() {
 		fmt.Print(clientHelp)
 		os.Exit(0)
 	}
 	flags.Parse(args)
-	config, err := chclient.NewClientConfig(*profilePath)
+	config, err := chclient.NewClientConfig(*profilePath, config)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -451,7 +451,7 @@ func client(args []string) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	c.Debug = *verbose
+	c.Debug = *verbose || config.Verbose
 	if *pid {
 		generatePidFile()
 	}


### PR DESCRIPTION
There was an issue with how we read profile yaml in client. Values from CLI and yaml were not being merged correctly and incorrect default values were being set for CLI args.