### PR TITLE
Added rest API to create/update/delete users remotely

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ lint: ## Lint the files
 	@go vet ${GOFILESNOTEST}
 
 test: ## Run unit tests
-	@go test -coverprofile=${DIR}/coverage.out -race -short ${GOFILESNOTEST}
+	@go test ./... -coverprofile=${DIR}/coverage.out -race -short ${GOFILESNOTEST}
 	@go tool cover -html=${DIR}/coverage.out -o ${DIR}/coverage.html
 	#@gocover-cobertura < ${DIR}/coverage.out > ${DIR}/coverage.xml
 

--- a/example/users.json
+++ b/example/users.json
@@ -1,13 +1,25 @@
-{
-	"root:toor": [
-		""
-	],
-	"foo:bar": [
-		"^9001",
-		"^9002",
-		"^9003"
-	],
-	"ping:pong": [
-		"^80[0-9]{2}"
-	]
-}
+[
+	{
+		"username": "root",
+		"password": "toor",
+		"addresses": ["*"],
+		"is_admin": true
+	},
+	{
+		"username": "foo",
+		"password": "bar",
+		"addresses": [
+			"^9001",
+			"^9002",
+			"^9003"
+		],
+		"is_admin": false
+	},
+	{
+		"username": "ping",
+		"password": "pong",
+		"addresses": ["^80[0-9]{2}"],
+		"is_admin": false
+	}
+]
+

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/jpillora/requestlog v1.0.0
 	github.com/jpillora/sizestr v1.0.0
 	golang.org/x/crypto v0.23.0
+	golang.org/x/exp v0.0.0-20240525044651-4c93da0ed11d
 	golang.org/x/net v0.25.0
 	golang.org/x/sync v0.7.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce h1:fb190+cK2Xz/dvi9
 github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoik09Xen7gje4m9ERNah1d1PPsVq1VEx9vE4=
 golang.org/x/crypto v0.23.0 h1:dIJU/v2J8Mdglj/8rJ6UUOM3Zc9zLZxVZwwxMooUSAI=
 golang.org/x/crypto v0.23.0/go.mod h1:CKFgDieR+mRhux2Lsu27y0fO304Db0wZe70UKqHu0v8=
+golang.org/x/exp v0.0.0-20240525044651-4c93da0ed11d h1:N0hmiNbwsSNwHBAvR3QB5w25pUwH4tK0Y/RltD1j1h4=
+golang.org/x/exp v0.0.0-20240525044651-4c93da0ed11d/go.mod h1:XtvwrStGgqGPLc4cjQfWqZHG1YFdYs6swckp8vpsjnc=
 golang.org/x/net v0.25.0 h1:d/OCCoBEUq33pjydKrGQhw7IlUPI2Oylr+8qLx49kac=
 golang.org/x/net v0.25.0/go.mod h1:JkAGAh7GEvH74S6FOH42FLoXpXbE/aqXSrIQjXgsiwM=
 golang.org/x/sync v0.7.0 h1:YsImfSBoP9QPYL0xyKJPq0gcaJdG3rInoqxTWbfQu9M=

--- a/server/server.go
+++ b/server/server.go
@@ -70,6 +70,7 @@ func NewServer(c *Config) (*Server, error) {
 	}
 	if c.Auth != "" {
 		u := &settings.User{Addrs: []*regexp.Regexp{settings.UserAllowAll}}
+		u.IsAdmin = true
 		u.Name, u.Pass = settings.ParseAuth(c.Auth)
 		if u.Name != "" {
 			server.users.AddUser(u)

--- a/server/server_rest.go
+++ b/server/server_rest.go
@@ -1,0 +1,258 @@
+package chserver
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"github.com/NextChapterSoftware/chissl/share/settings"
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+type UpdateUserRequest struct {
+	Name    string           `json:"username"`
+	Pass    string           `json:"password,omitempty"`
+	Addrs   []*regexp.Regexp `json:"addresses,omitempty"`
+	IsAdmin bool             `json:"is_admin"`
+}
+
+// decodeBasicAuthHeader extracts the username and password from auth headers
+func (s *Server) decodeBasicAuthHeader(headers http.Header) (username, password string, ok bool) {
+	authHeader := headers.Get("Authorization")
+	if authHeader == "" {
+		return "", "", false
+	}
+	const basicAuthPrefix = "Basic "
+	if !strings.HasPrefix(authHeader, basicAuthPrefix) {
+		return "", "", false
+	}
+
+	// Decode the base64 encoded username:password
+	decoded, err := base64.StdEncoding.DecodeString(authHeader[len(basicAuthPrefix):])
+	if err != nil {
+		return "", "", false
+	}
+
+	// Split the username and password
+	credentials := strings.SplitN(string(decoded), ":", 2)
+	if len(credentials) != 2 {
+		return "", "", false
+	}
+
+	return credentials[0], credentials[1], true
+}
+
+// BasicAuthMiddleware validates the username and password
+func (s *Server) basicAuthMiddleware(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if strings.TrimSpace(s.config.AuthFile) == "" {
+			http.Error(w, "No auth file configured on server", http.StatusUnauthorized)
+			return
+		}
+
+		username, password, ok := s.decodeBasicAuthHeader(r.Header)
+		if !ok {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+		u, found := s.users.Get(username)
+
+		// Validate the credentials (Replace with your validation logic)
+		if !found || username != u.Name || password != u.Pass || !u.IsAdmin {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		// Proceed with the next handler
+		next.ServeHTTP(w, r)
+	}
+}
+
+func getUsernameFromPath(path string) (string, error) {
+	// Define the expected URL pattern
+	pattern := `^/user/([^/]+)$`
+	re := regexp.MustCompile(pattern)
+
+	// Check if the path matches the pattern
+	matches := re.FindStringSubmatch(path)
+	if matches == nil {
+		return "", fmt.Errorf("invalid URL format: %s", path)
+	}
+	return matches[1], nil
+}
+
+func (s *Server) handleGetUsers(w http.ResponseWriter, r *http.Request) {
+	data, err := s.users.ToJSON()
+	if err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	w.Write([]byte(data))
+}
+
+func (s *Server) handleGetUser(w http.ResponseWriter, r *http.Request) {
+	username, err := getUsernameFromPath(r.URL.Path)
+	if err != nil {
+		http.Error(w, "Bad request", http.StatusBadRequest)
+		return
+	}
+
+	u, found := s.users.Get(username)
+	if !found {
+		http.Error(w, "User not found", http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	responseJson, err := u.ToJSON()
+	if err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	w.Write([]byte(responseJson))
+}
+
+func (s *Server) handleAddUser(w http.ResponseWriter, r *http.Request) {
+	// Parse the request body to create a User object
+	var newUser settings.User
+	if err := json.NewDecoder(r.Body).Decode(&newUser); err != nil {
+		http.Error(w, "Invalid request payload", http.StatusBadRequest)
+		return
+	}
+
+	// Validate the user input
+	if err := newUser.ValidateUser(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	_, found := s.users.Get(newUser.Name)
+	if found {
+		http.Error(w, "User already exists", http.StatusConflict)
+		return
+	}
+
+	// Add the user to the server's user collection
+	s.users.Set(newUser.Name, &newUser)
+	err := s.users.WriteUsers()
+	if err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	// Respond with a status indicating success
+	w.WriteHeader(http.StatusCreated)
+}
+
+func (s *Server) handleUpdateUser(w http.ResponseWriter, r *http.Request) {
+	// Parse the request body to create a User object
+	var targetUser settings.User
+	if err := json.NewDecoder(r.Body).Decode(&targetUser); err != nil {
+		http.Error(w, "Invalid request payload", http.StatusBadRequest)
+		return
+	}
+
+	targetUserFromLookup, found := s.users.Get(targetUser.Name)
+	if !found {
+		http.Error(w, "User not found", http.StatusNotFound)
+		return
+	}
+
+	// Get current user making this request
+	requestingUser, _, _ := s.decodeBasicAuthHeader(r.Header)
+
+	// Admins cannot revoke admin permission from themselves
+	if !targetUser.IsAdmin && targetUser.Name == requestingUser {
+		http.Error(w, "Cannot revoke admin from yourself", http.StatusBadRequest)
+		return
+	}
+
+	if targetUser.Pass == "" {
+		targetUser.Pass = targetUserFromLookup.Pass
+	}
+
+	if len(targetUser.Addrs) == 0 {
+		targetUser.Addrs = targetUserFromLookup.Addrs
+	}
+
+	s.users.Set(targetUser.Name, &targetUser)
+	err := s.users.WriteUsers()
+	if err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	// Implement user update logic here
+	w.WriteHeader(http.StatusAccepted)
+}
+
+func (s *Server) handleDeleteUser(w http.ResponseWriter, r *http.Request) {
+	username, err := getUsernameFromPath(r.URL.Path)
+	if err != nil {
+		http.Error(w, "Bad request", http.StatusBadRequest)
+		return
+	}
+
+	u, found := s.users.Get(username)
+	if !found {
+		http.Error(w, "User not found", http.StatusNotFound)
+		return
+	}
+
+	// Get current user making this request
+	requestingUser, _, _ := s.decodeBasicAuthHeader(r.Header)
+	if requestingUser == u.Name {
+		http.Error(w, "Cannot delete your own user", http.StatusBadRequest)
+		return
+	}
+
+	s.users.Del(u.Name)
+	err = s.users.WriteUsers()
+	if err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusAccepted)
+}
+
+func (s *Server) handleAuthfile(w http.ResponseWriter, r *http.Request) {
+	// Parse the request body to create a User object
+	var users []*settings.User
+	if err := json.NewDecoder(r.Body).Decode(&users); err != nil {
+		http.Error(w, "Invalid request payload", http.StatusBadRequest)
+		return
+	}
+
+	if len(users) == 0 {
+		http.Error(w, "No users found in file", http.StatusBadRequest)
+	}
+
+	// Get current user making this request
+	requestingUser, _, _ := s.decodeBasicAuthHeader(r.Header)
+	u, _ := s.users.Get(requestingUser)
+
+	requestingUserFromPayload := &settings.User{}
+	for _, user := range users {
+		err := user.ValidateUser()
+		if err != nil {
+			http.Error(w, fmt.Sprintf("invalid user setting for %s: %v", user.Name, err), http.StatusBadRequest)
+		}
+		if user.Name == u.Name {
+			requestingUserFromPayload = user
+		}
+	}
+	if requestingUserFromPayload == nil || !requestingUserFromPayload.IsAdmin {
+		http.Error(w, "file must include the current requesting user with admin permission", http.StatusBadRequest)
+		return
+	}
+
+	s.users.Reset(users)
+	err := s.users.WriteUsers()
+	if err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+	// Implement user update logic here
+	w.WriteHeader(http.StatusAccepted)
+}

--- a/server/server_rest_test.go
+++ b/server/server_rest_test.go
@@ -1,0 +1,627 @@
+package chserver
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"github.com/NextChapterSoftware/chissl/share/settings"
+	"io"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+const debug = true
+
+// test layout configuration
+type testLayout struct {
+	server     *Config
+	serverPort string
+}
+
+func (tl *testLayout) GetServerPort() string { return tl.serverPort }
+func (tl *testLayout) setup(t *testing.T) (server *Server, teardown func()) {
+	//start of the world
+	ctx, cancel := context.WithCancel(context.Background())
+
+	//server
+	server, err := NewServer(tl.server)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server.Debug = debug
+	port := "8080" //availablePort()
+	tl.serverPort = port
+	if err := server.StartContext(ctx, "127.0.0.1", port); err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		server.Wait()
+		server.Infof("Closed")
+		cancel()
+	}()
+
+	//cancel context tree, and wait for both client and server to stop
+	teardown = func() {
+		cancel()
+		server.Wait()
+		//confirm goroutines have been cleaned up
+		// time.Sleep(500 * time.Millisecond)
+		// TODO remove sleep
+		// d := runtime.NumGoroutine() - goroutines
+		// if d != 0 {
+		// 	pprof.Lookup("goroutine").WriteTo(os.Stdout, 1)
+		// 	t.Fatalf("goroutines left %d", d)
+		// }
+	}
+	//wait a bit...
+	//TODO: client signal API, similar to os.Notify(signal)
+	//      wait for client setup
+	time.Sleep(50 * time.Millisecond)
+	//ready
+	return server, teardown
+}
+
+func simpleSetup(t *testing.T, s *Config) (context.CancelFunc, *testLayout) {
+	conf := testLayout{
+		server: s,
+	}
+	_, teardown := conf.setup(t)
+	return teardown, &conf
+}
+
+func createTempAuthFile(t *testing.T) string {
+	t.Helper()
+	authFileContent := `[
+				 {"username":"root","password":"toor1234","addresses":[".*"],"is_admin":true},
+				 {"username":"foo","password":"bar12345","addresses":["^9001","^9002","^9003"],"is_admin":false},
+				 {"username":"ping","password":"pong1234","addresses":["^80[0-9]{2}"],"is_admin":false}
+				]`
+	tmpFile, err := os.CreateTemp("", "auth-*.json")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+
+	if _, err := tmpFile.Write([]byte(authFileContent)); err != nil {
+		t.Fatalf("Failed to write to temp file: %v", err)
+	}
+
+	if err := tmpFile.Close(); err != nil {
+		t.Fatalf("Failed to close temp file: %v", err)
+	}
+
+	return tmpFile.Name()
+}
+
+func httpRequestWithBodyWithBasicAuth(method, url, body, username, password string) (string, error) {
+	// Create a new request with the given URL and body
+	req, err := http.NewRequest(strings.ToUpper(method), url, strings.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+
+	// Set the Basic Auth header
+	auth := username + ":" + password
+	encodedAuth := base64.StdEncoding.EncodeToString([]byte(auth))
+	req.Header.Set("Authorization", "Basic "+encodedAuth)
+
+	// Create a custom http.Client with the Basic Auth header
+	client := &http.Client{}
+
+	// Perform the request using the custom client
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	// Read the response body
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(b), nil
+}
+
+func httpRequestNoBodyWithBasicAuth(method, url, username, password string) (string, error) {
+	// Create a new request
+	req, err := http.NewRequest(strings.ToUpper(method), url, nil)
+	if err != nil {
+		return "", err
+	}
+
+	// Set the Basic Auth header
+	auth := username + ":" + password
+	encodedAuth := base64.StdEncoding.EncodeToString([]byte(auth))
+	req.Header.Set("Authorization", "Basic "+encodedAuth)
+
+	// Perform the request
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	// Read the response body
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func get(url string) (string, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func TestHttpRequestNoAuth(t *testing.T) {
+
+	teardown, tl := simpleSetup(t, &Config{})
+	defer teardown()
+
+	result, err := get("http://127.0.0.1:" + tl.GetServerPort() + "/health")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "OK\n" {
+		t.Fatalf("vailid path with no auth - expected OK\\n but got '%s'", result)
+	}
+
+	result, err = get("http://127.0.0.1:" + tl.GetServerPort() + "/healthIgnoreExtraPathComponents/123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "OK\n" {
+		t.Fatalf("path with valid prefix and no auth - expected OK\\n but got '%s'", result)
+	}
+
+	result, err = get("http://127.0.0.1:" + tl.GetServerPort() + "/ThishealthEndpointDoesntexist")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "Not found" {
+		t.Fatalf("invalid path - expected 'Not found' but got '%s'", result)
+	}
+}
+
+func TestGetUserWithAuth(t *testing.T) {
+	teardown, tl := simpleSetup(t, &Config{
+		Auth: "admin:password",
+	})
+
+	// No auth file configured - Must fail
+	result, err := get("http://127.0.0.1:" + tl.GetServerPort() + "/user/admin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "No auth file configured on server\n" {
+		t.Fatalf("no auth info - expected 'No auth file configured on server' but got '%s'", result)
+	}
+	teardown()
+
+	authFilePath := createTempAuthFile(t)
+	defer os.Remove(authFilePath)
+	teardown, tl = simpleSetup(t, &Config{
+		AuthFile: authFilePath,
+	})
+	defer teardown()
+
+	// No auth info provided - Must fail
+	result, err = get("http://127.0.0.1:" + tl.GetServerPort() + "/user/admin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "Unauthorized\n" {
+		t.Fatalf("no auth info - expected 'Unauthorized' but got '%s'", result)
+	}
+
+	// Correct auth info provided - Must pass
+	result, err = httpRequestNoBodyWithBasicAuth(
+		http.MethodGet,
+		"http://127.0.0.1:"+tl.GetServerPort()+"/user/ping",
+		"root",
+		"toor1234",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "{\"username\":\"ping\",\"password\":\"pong1234\",\"addresses\":[\"^80[0-9]{2}\"],\"is_admin\":false}" {
+		t.Fatalf("valid auth info - expected user info json but got '%s'", result)
+	}
+
+	// Wrong auth info provided - Must fail
+	result, err = httpRequestNoBodyWithBasicAuth(
+		http.MethodGet,
+		"http://127.0.0.1:"+tl.GetServerPort()+"/user/admin",
+		"root",
+		"WrongPassword",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "Unauthorized\n" {
+		t.Fatalf("invalid password - expected 'Unauthorized' but got '%s'", result)
+	}
+
+	// Wrong auth info provided - Must fail
+	result, err = httpRequestNoBodyWithBasicAuth(
+		http.MethodGet,
+		"http://127.0.0.1:"+tl.GetServerPort()+"/user/admin",
+		"userthatdoesntexist",
+		"password",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "Unauthorized\n" {
+		t.Fatalf("invalid username - expected 'Unauthorized' but got '%s'", result)
+	}
+}
+
+func TestAddUserWithAuth(t *testing.T) {
+
+	authFilePath := createTempAuthFile(t)
+	defer os.Remove(authFilePath)
+	teardown, tl := simpleSetup(t, &Config{
+		AuthFile: authFilePath,
+	})
+	defer teardown()
+
+	u := &settings.User{
+		Name:    "nonAdminUser",
+		Pass:    "password1",
+		Addrs:   []*regexp.Regexp{settings.UserAllowAll},
+		IsAdmin: false,
+	}
+
+	userJson, err := json.Marshal(u)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := httpRequestWithBodyWithBasicAuth(
+		http.MethodPost,
+		"http://127.0.0.1:"+tl.GetServerPort()+"/user",
+		string(userJson),
+		"root",
+		"toor1234",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "" {
+		t.Fatalf("create valid user - expected to '' but got '%s'", result)
+	}
+
+	// Correct auth info provided - Must pass
+	result, err = httpRequestNoBodyWithBasicAuth(
+		http.MethodGet,
+		"http://127.0.0.1:"+tl.GetServerPort()+"/user/nonAdminUser",
+		"root",
+		"toor1234",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "{\"username\":\"nonAdminUser\",\"password\":\"password1\",\"addresses\":[\".*\"],\"is_admin\":false}" {
+		t.Fatalf("get new userinfo - expected user info json but got '%s'", result)
+	}
+
+	result, err = httpRequestWithBodyWithBasicAuth(
+		http.MethodPost,
+		"http://127.0.0.1:"+tl.GetServerPort()+"/user",
+		string(userJson),
+		"root",
+		"toor1234",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "User already exists\n" {
+		t.Fatalf("created duplicate user - expected to 'ser already exists\\n' but got '%s'", result)
+	}
+}
+
+func TestUpdateUserWithAuth(t *testing.T) {
+
+	authFilePath := createTempAuthFile(t)
+	defer os.Remove(authFilePath)
+	teardown, tl := simpleSetup(t, &Config{
+		AuthFile: authFilePath,
+	})
+	defer teardown()
+	u := &UpdateUserRequest{
+		Name: "foo",
+		//Pass:    "password1",
+		Addrs:   []*regexp.Regexp{settings.UserAllowAll},
+		IsAdmin: true,
+	}
+
+	userJson, err := json.Marshal(u)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := httpRequestWithBodyWithBasicAuth(
+		http.MethodPut,
+		"http://127.0.0.1:"+tl.GetServerPort()+"/user",
+		string(userJson),
+		"root",
+		"toor1234",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "" {
+		t.Fatalf("update valid user - expected to '' but got '%s'", result)
+	}
+
+	// Correct auth info provided - Must pass
+	result, err = httpRequestNoBodyWithBasicAuth(
+		http.MethodGet,
+		"http://127.0.0.1:"+tl.GetServerPort()+"/user/"+u.Name,
+		"root",
+		"toor1234",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updatedUser := &settings.User{}
+	err = json.Unmarshal(userJson, updatedUser)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !updatedUser.IsAdmin {
+		t.Fatalf("failed to update admin flag for user")
+	}
+
+	if len(updatedUser.Addrs) != 1 {
+		t.Fatalf("failed to update addresses user")
+	}
+}
+
+func TestDeleteUserWithAuth(t *testing.T) {
+
+	authFilePath := createTempAuthFile(t)
+	defer os.Remove(authFilePath)
+	teardown, tl := simpleSetup(t, &Config{
+		AuthFile: authFilePath,
+	})
+	defer teardown()
+
+	// Invalid auth info provided - Must fail
+	result, err := httpRequestNoBodyWithBasicAuth(
+		http.MethodDelete,
+		"http://127.0.0.1:"+tl.GetServerPort()+"/user/ping",
+		"root",
+		"WrongPassword",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "Unauthorized\n" {
+		t.Fatalf("no auth info - expected 'Unauthorized' but got '%s'", result)
+	}
+
+	// Correct auth but user doesn't exist - Must fail
+	result, err = httpRequestNoBodyWithBasicAuth(
+		http.MethodDelete,
+		"http://127.0.0.1:"+tl.GetServerPort()+"/user/admin",
+		"root",
+		"toor1234",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(result, "User not found") {
+		t.Fatalf("user does not exist - expected 'User not found' but got '%s'", result)
+	}
+
+	// Deleting requester (self) user - Must fail
+	result, err = httpRequestNoBodyWithBasicAuth(
+		http.MethodDelete,
+		"http://127.0.0.1:"+tl.GetServerPort()+"/user/root",
+		"root",
+		"toor1234",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(result, "Cannot delete your own user") {
+		t.Fatalf("no deleting self - expected user 'Cannot delete your own user' but got '%s'", result)
+	}
+
+	// Valid delete request requester (self) user - Must pass
+	result, err = httpRequestNoBodyWithBasicAuth(
+		http.MethodDelete,
+		"http://127.0.0.1:"+tl.GetServerPort()+"/user/ping",
+		"root",
+		"toor1234",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "" {
+		t.Fatalf("no deleting self - expected user to pass but got '%s'", result)
+	}
+
+	// Verify user has been deleted - Must pass
+	result, err = httpRequestNoBodyWithBasicAuth(
+		http.MethodDelete,
+		"http://127.0.0.1:"+tl.GetServerPort()+"/user/ping",
+		"root",
+		"toor1234",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(result, "User not found") {
+		t.Fatalf("verify delete success - expected 'User not found' but got '%s'", result)
+	}
+}
+
+func TestGetUsersWithAuth(t *testing.T) {
+	authFilePath := createTempAuthFile(t)
+	defer os.Remove(authFilePath)
+	teardown, tl := simpleSetup(t, &Config{
+		AuthFile: authFilePath,
+	})
+	defer teardown()
+
+	// No auth info provided - Must fail
+	result, err := get("http://127.0.0.1:" + tl.GetServerPort() + "/users")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "Unauthorized\n" {
+		t.Fatalf("no auth info - expected 'Unauthorized' but got '%s'", result)
+	}
+
+	// Correct auth info provided - Must pass
+	result, err = httpRequestNoBodyWithBasicAuth(
+		http.MethodGet,
+		"http://127.0.0.1:"+tl.GetServerPort()+"/users",
+		"root",
+		"toor1234",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	users := []*settings.User{}
+	err = json.Unmarshal([]byte(result), &users)
+	if len(users) != 3 {
+		t.Fatalf("list of all users - expected user info json for all users but got '%s'", result)
+	}
+}
+
+func TestAddAuthfile(t *testing.T) {
+
+	authFilePath := createTempAuthFile(t)
+	defer os.Remove(authFilePath)
+	teardown, tl := simpleSetup(t, &Config{
+		AuthFile: authFilePath,
+	})
+	defer teardown()
+
+	// Invalid auth file - admin flag for requesting user is being set to false
+	usersJson := `[
+				 {"username":"root","password":"toor1234","addresses":[".*"],"is_admin":false},
+				 {"username":"foo","password":"bar12345","addresses":["^9001","^9002","^9003"],"is_admin":false},
+				 {"username":"ping","password":"pong1234","addresses":["^80[0-9]{2}"],"is_admin":false}
+				]`
+
+	result, err := httpRequestWithBodyWithBasicAuth(
+		http.MethodPost,
+		"http://127.0.0.1:"+tl.GetServerPort()+"/authfile",
+		usersJson,
+		"root",
+		"toor1234",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(result, "file must include the current requesting user with admin permission") {
+		t.Fatalf("invalid file - expected to fail but got '%s'", result)
+	}
+
+	// Invalid auth file - empty file
+	result, err = httpRequestWithBodyWithBasicAuth(
+		http.MethodPost,
+		"http://127.0.0.1:"+tl.GetServerPort()+"/authfile",
+		"[]",
+		"root",
+		"toor1234",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(result, "No users found in file") {
+		t.Fatalf("invalid file - expected to fail but got '%s'", result)
+	}
+
+	// Invalid user settings in file - foo has no addresses assigned
+	usersJson = `[
+				 {"username":"root","password":"toor1234","addresses":[".*"],"is_admin":true},
+				 {"username":"foo","password":"bar12345","addresses":[],"is_admin":false},
+				 {"username":"ping","password":"pong1234","addresses":["^80[0-9]{2}"],"is_admin":false}
+				]`
+
+	result, err = httpRequestWithBodyWithBasicAuth(
+		http.MethodPost,
+		"http://127.0.0.1:"+tl.GetServerPort()+"/authfile",
+		usersJson,
+		"root",
+		"toor1234",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(result, "invalid user setting for") {
+		t.Fatalf("invalid file - expected to fail but got '%s'", result)
+	}
+
+	// Valid auth file with new user and modifications to existing user
+	usersJson = `[
+				 {"username":"root","password":"toor1234","addresses":[".*"],"is_admin":true},
+				 {"username":"foo","password":"bar12345","addresses":["^9001"],"is_admin":false},
+				 {"username":"newuser","password":"newuser1234","addresses":["^80[0-9]{2}"],"is_admin":false}
+				]`
+
+	result, err = httpRequestWithBodyWithBasicAuth(
+		http.MethodPost,
+		"http://127.0.0.1:"+tl.GetServerPort()+"/authfile",
+		usersJson,
+		"root",
+		"toor1234",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result != "" {
+		t.Fatalf("valid file - expected to pass but got '%s'", result)
+	}
+
+	// Deleted user foo - Must fail
+	result, err = httpRequestNoBodyWithBasicAuth(
+		http.MethodGet,
+		"http://127.0.0.1:"+tl.GetServerPort()+"/user/foor",
+		"root",
+		"toor1234",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(result, "User not found") {
+		t.Fatalf("deleted user- expected user to fail but got '%s'", result)
+	}
+
+	// Newly created user - Must pass
+	result, err = httpRequestNoBodyWithBasicAuth(
+		http.MethodGet,
+		"http://127.0.0.1:"+tl.GetServerPort()+"/user/newuser",
+		"root",
+		"toor1234",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(result, "newuser1234") {
+		t.Fatalf("valid user info - expected user info json but got '%s'", result)
+	}
+
+}

--- a/share/settings/remote.go
+++ b/share/settings/remote.go
@@ -105,7 +105,7 @@ func L4Proto(s string) (head, proto string) {
 func (r Remote) String() string {
 	sb := strings.Builder{}
 	sb.WriteString(strings.TrimPrefix(r.Local(), "0.0.0.0:"))
-	sb.WriteString("=>")
+	sb.WriteString("->")
 	sb.WriteString(strings.TrimPrefix(r.Remote(), "127.0.0.1:"))
 	return sb.String()
 }
@@ -116,9 +116,7 @@ func (r Remote) Encode() string {
 }
 
 // Local is the decodable local portion
-func (r Remote) Local() string {
-	return r.LocalHost + ":" + r.LocalPort
-}
+func (r Remote) Local() string { return r.LocalHost + ":" + r.LocalPort }
 
 // Remote is the decodable remote portion
 func (r Remote) Remote() string {

--- a/share/settings/user.go
+++ b/share/settings/user.go
@@ -1,11 +1,14 @@
 package settings
 
 import (
+	"encoding/json"
+	"errors"
 	"regexp"
 	"strings"
+	"unicode"
 )
 
-var UserAllowAll = regexp.MustCompile("")
+var UserAllowAll = regexp.MustCompile(".*")
 
 func ParseAuth(auth string) (string, string) {
 	if strings.Contains(auth, ":") {
@@ -16,9 +19,10 @@ func ParseAuth(auth string) (string, string) {
 }
 
 type User struct {
-	Name  string
-	Pass  string
-	Addrs []*regexp.Regexp
+	Name    string           `json:"username"`
+	Pass    string           `json:"password"`
+	Addrs   []*regexp.Regexp `json:"addresses"`
+	IsAdmin bool             `json:"is_admin"`
 }
 
 func (u *User) HasAccess(addr string) bool {
@@ -30,4 +34,40 @@ func (u *User) HasAccess(addr string) bool {
 		}
 	}
 	return m
+}
+
+// ValidateUser validates the fields of the User struct
+func (u *User) ValidateUser() error {
+	// Validate Name: alphanumeric, no special characters
+	for _, r := range u.Name {
+		if !unicode.IsLetter(r) && !unicode.IsNumber(r) {
+			return errors.New("name must be alphanumeric with no special characters")
+		}
+	}
+
+	// Validate Password: minimum length of 8 characters
+	if len(u.Pass) < 8 {
+		return errors.New("password must have a minimum length of 8 characters")
+	}
+
+	// Validate Addrs: each address must have a minimum length of 1
+	if len(u.Addrs) == 0 {
+		return errors.New(" at least one address must be provided")
+	}
+	for _, r := range u.Addrs {
+		if len(r.String()) == 0 {
+			return errors.New("address regex must not be empty. supply '.*' to match all")
+		}
+	}
+
+	return nil
+}
+
+func (u *User) ToJSON() (string, error) {
+	jsonData, err := json.Marshal(u)
+	if err != nil {
+		return "", err
+	}
+
+	return string(jsonData), nil
 }

--- a/share/tunnel/tunnel.go
+++ b/share/tunnel/tunnel.go
@@ -160,7 +160,7 @@ func (t *Tunnel) BindRemotes(ctx context.Context, remotes []*settings.Remote) er
 		if !t.IsClient {
 			tlsConf = t.TlsConf
 		}
-		p, err := NewProxy(t.Logger, t, t.proxyCount, remote, tlsConf)
+		p, err := NewProxy(t.Logger, t, t.proxyCount, remote, tlsConf, t.IsClient)
 		if err != nil {
 			return err
 		}

--- a/test/e2e/auth_test.go
+++ b/test/e2e/auth_test.go
@@ -1,0 +1,48 @@
+package e2e_test
+
+import (
+	"testing"
+
+	chclient "github.com/NextChapterSoftware/chissl/client"
+	chserver "github.com/NextChapterSoftware/chissl/server"
+)
+
+//TODO tests for:
+// - failed auth
+// - dynamic auth (server add/remove user)
+// - watch auth file
+
+func TestAuth(t *testing.T) {
+	tmpPort1 := availablePort()
+	tmpPort2 := availablePort()
+	//setup server, client, fileserver
+	teardown := simpleSetup(t,
+		&chserver.Config{
+			KeySeed: "foobar",
+			Auth:    "../bench/userfile",
+		},
+		&chclient.Config{
+			Remotes: []string{
+				tmpPort1 + ":0.0.0.0->$FILEPORT:127.0.0.1",
+				tmpPort2 + ":0.0.0.0->$FILEPORT:localhost",
+			},
+			Auth: "foo:bar",
+		})
+	defer teardown()
+	//test first remote
+	result, err := post("http://localhost:"+tmpPort1, "foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "foo!" {
+		t.Fatalf("expected exclamation mark added")
+	}
+	//test second remote
+	result, err = post("http://localhost:"+tmpPort2, "bar")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "bar!" {
+		t.Fatalf("expected exclamation mark added again")
+	}
+}

--- a/test/e2e/base_test.go
+++ b/test/e2e/base_test.go
@@ -1,0 +1,63 @@
+package e2e_test
+
+import (
+	chclient "github.com/NextChapterSoftware/chissl/client"
+	chserver "github.com/NextChapterSoftware/chissl/server"
+	"testing"
+)
+
+func TestReverse(t *testing.T) {
+	tmpPort := availablePort()
+	//setup server, client, fileserver
+	teardown := simpleSetup(t,
+		&chserver.Config{
+			Auth:    "admin:admin",
+			Reverse: true,
+			/*	TLS: chserver.TLSConfig{
+				Domains: []string{"localhost", "127.0.0.1"},
+			},*/
+		},
+		&chclient.Config{
+			Remotes: []string{tmpPort + ":127.0.0.1->$FILEPORT"},
+			Auth:    "admin:admin",
+			//Remotes: []string{"$FILEPORT:127.0.0.1->" + tmpPort},
+		})
+	defer teardown()
+	//test remote (this goes through the server and out the client)
+	result, err := post("http://localhost:"+tmpPort, "foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "foo!" {
+		t.Fatalf("expected exclamation mark added")
+	}
+}
+
+func TestReverseMTLS_SSL(t *testing.T) {
+	tlsConfig, err := newTestTLSConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tlsConfig.Close()
+	tmpPort := availablePort()
+	//setup server, client, fileserver
+	teardown := simpleSetup(t,
+		&chserver.Config{
+			//Auth: "admin:admin",
+			TLS: *tlsConfig.serverTLS,
+		},
+		&chclient.Config{
+			Remotes: []string{tmpPort + "->$FILEPORT"},
+			//Auth:    "admin:admin",
+			TLS: *tlsConfig.clientTLS,
+		})
+	defer teardown()
+	//test remote (this goes through the server and out the client)
+	result, err := postWithTls("https://localhost:"+tmpPort, "foo", tlsConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "foo!" {
+		t.Fatalf("expected exclamation mark added")
+	}
+}

--- a/test/e2e/cert_utils_test.go
+++ b/test/e2e/cert_utils_test.go
@@ -1,0 +1,256 @@
+package e2e_test
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"path"
+	"time"
+
+	chclient "github.com/NextChapterSoftware/chissl/client"
+	chserver "github.com/NextChapterSoftware/chissl/server"
+)
+
+type tlsConfig struct {
+	serverTLS *chserver.TLSConfig
+	clientTLS *chclient.TLSConfig
+	tmpDir    string
+}
+
+func (t *tlsConfig) Close() {
+	if t.tmpDir != "" {
+		os.RemoveAll(t.tmpDir)
+	}
+}
+
+func newTestTLSConfig() (*tlsConfig, error) {
+	tlsConfig := &tlsConfig{}
+	_, serverCertPEM, serverKeyPEM, err := certGetCertificate(&certConfig{
+		hosts: []string{
+			"0.0.0.0",
+			"localhost",
+		},
+		extKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	})
+	if err != nil {
+		return nil, err
+	}
+	_, clientCertPEM, clientKeyPEM, err := certGetCertificate(&certConfig{
+		extKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	tlsConfig.tmpDir, err = os.MkdirTemp("", "")
+	if err != nil {
+		return nil, err
+	}
+
+	dirServerCA := path.Join(tlsConfig.tmpDir, "server-ca")
+	if err := os.Mkdir(dirServerCA, 0777); err != nil {
+		return nil, err
+	}
+	pathServerCACrt := path.Join(dirServerCA, "client.crt")
+	if err := os.WriteFile(pathServerCACrt, clientCertPEM, 0666); err != nil {
+		return nil, err
+	}
+
+	dirClientCA := path.Join(tlsConfig.tmpDir, "client-ca")
+	if err := os.Mkdir(dirClientCA, 0777); err != nil {
+		return nil, err
+	}
+	pathClientCACrt := path.Join(dirClientCA, "server.crt")
+	if err := os.WriteFile(pathClientCACrt, serverCertPEM, 0666); err != nil {
+		return nil, err
+	}
+
+	dirServerCrt := path.Join(tlsConfig.tmpDir, "server-crt")
+	if err := os.Mkdir(dirServerCrt, 0777); err != nil {
+		return nil, err
+	}
+	pathServerCrtCrt := path.Join(dirServerCrt, "server.crt")
+	if err := os.WriteFile(pathServerCrtCrt, serverCertPEM, 0666); err != nil {
+		return nil, err
+	}
+	pathServerCrtKey := path.Join(dirServerCrt, "server.key")
+	if err := os.WriteFile(pathServerCrtKey, serverKeyPEM, 0666); err != nil {
+		return nil, err
+	}
+
+	dirClientCrt := path.Join(tlsConfig.tmpDir, "client-crt")
+	if err := os.Mkdir(dirClientCrt, 0777); err != nil {
+		return nil, err
+	}
+	pathClientCrtCrt := path.Join(dirClientCrt, "client.crt")
+	if err := os.WriteFile(pathClientCrtCrt, clientCertPEM, 0666); err != nil {
+		return nil, err
+	}
+	pathClientCrtKey := path.Join(dirClientCrt, "client.key")
+	if err := os.WriteFile(pathClientCrtKey, clientKeyPEM, 0666); err != nil {
+		return nil, err
+	}
+
+	// for self signed cert, it needs the server cert, for real cert, this need to be the trusted CA cert
+	tlsConfig.serverTLS = &chserver.TLSConfig{
+		CA:   pathServerCACrt,
+		Cert: pathServerCrtCrt,
+		Key:  pathServerCrtKey,
+	}
+	tlsConfig.clientTLS = &chclient.TLSConfig{
+		CA:   pathClientCACrt,
+		Cert: pathClientCrtCrt,
+		Key:  pathClientCrtKey,
+	}
+	return tlsConfig, nil
+}
+
+type certConfig struct {
+	signCA      *x509.Certificate
+	isCA        bool
+	hosts       []string
+	validFrom   *time.Time
+	validFor    *time.Time
+	extKeyUsage []x509.ExtKeyUsage
+	rsaBits     int
+	ecdsaCurve  string
+	ed25519Key  bool
+}
+
+func certGetCertificate(c *certConfig) (*x509.Certificate, []byte, []byte, error) {
+	var err error
+	var priv interface{}
+	switch c.ecdsaCurve {
+	case "":
+		if c.ed25519Key {
+			_, priv, err = ed25519.GenerateKey(rand.Reader)
+		} else {
+			rsaBits := c.rsaBits
+			if rsaBits == 0 {
+				rsaBits = 2048
+			}
+			priv, err = rsa.GenerateKey(rand.Reader, rsaBits)
+		}
+	case "P224":
+		priv, err = ecdsa.GenerateKey(elliptic.P224(), rand.Reader)
+	case "P256":
+		priv, err = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	case "P384":
+		priv, err = ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	case "P521":
+		priv, err = ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	default:
+		return nil, nil, nil, fmt.Errorf("Unrecognized elliptic curve: %q", c.ecdsaCurve)
+	}
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("Failed to generate private key: %v", err)
+	}
+
+	// ECDSA, ED25519 and RSA subject keys should have the DigitalSignature
+	// KeyUsage bits set in the x509.Certificate template
+	keyUsage := x509.KeyUsageDigitalSignature
+	// Only RSA subject keys should have the KeyEncipherment KeyUsage bits set. In
+	// the context of TLS this KeyUsage is particular to RSA key exchange and
+	// authentication.
+	if _, isRSA := priv.(*rsa.PrivateKey); isRSA {
+		keyUsage |= x509.KeyUsageKeyEncipherment
+	}
+
+	notBefore := time.Now()
+	if c.validFrom != nil {
+		notBefore = *c.validFrom
+	}
+
+	notAfter := time.Now().Add(24 * time.Hour)
+	if c.validFor != nil {
+		notAfter = *c.validFor
+	}
+
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("Failed to generate serial number: %v", err)
+	}
+
+	cert := &x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			OrganizationalUnit: []string{"test"},
+			Organization:       []string{"Chisel"},
+			Country:            []string{"us"},
+			Province:           []string{"ma"},
+			Locality:           []string{"Boston"},
+			CommonName:         "localhost",
+		},
+		NotBefore: notBefore,
+		NotAfter:  notAfter,
+
+		KeyUsage:              keyUsage,
+		ExtKeyUsage:           c.extKeyUsage,
+		BasicConstraintsValid: true,
+	}
+
+	for _, h := range c.hosts {
+		if ip := net.ParseIP(h); ip != nil {
+			cert.IPAddresses = append(cert.IPAddresses, ip)
+		} else {
+			cert.DNSNames = append(cert.DNSNames, h)
+		}
+	}
+
+	if c.isCA {
+		cert.IsCA = true
+		cert.KeyUsage |= x509.KeyUsageCertSign
+	}
+
+	ca := cert
+	if c.signCA != nil {
+		ca = c.signCA
+	}
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, cert, ca, certGetPublicKey(priv), priv)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("Failed to create certificate: %v", err)
+	}
+
+	certPEM := new(bytes.Buffer)
+	pem.Encode(certPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certBytes,
+	})
+
+	privBytes, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("Unable to marshal private key: %v", err)
+	}
+	certPrivKeyPEM := new(bytes.Buffer)
+	pem.Encode(certPrivKeyPEM, &pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: privBytes,
+	})
+
+	return cert, certPEM.Bytes(), certPrivKeyPEM.Bytes(), nil
+}
+
+func certGetPublicKey(priv interface{}) interface{} {
+	switch k := priv.(type) {
+	case *rsa.PrivateKey:
+		return &k.PublicKey
+	case *ecdsa.PrivateKey:
+		return &k.PublicKey
+	case ed25519.PrivateKey:
+		return k.Public().(ed25519.PublicKey)
+	default:
+		return nil
+	}
+}

--- a/test/e2e/setup_test.go
+++ b/test/e2e/setup_test.go
@@ -1,0 +1,188 @@
+package e2e_test
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	chclient "github.com/NextChapterSoftware/chissl/client"
+	chserver "github.com/NextChapterSoftware/chissl/server"
+)
+
+const debug = true
+
+// test layout configuration
+type testLayout struct {
+	server     *chserver.Config
+	client     *chclient.Config
+	fileServer bool
+	udpEcho    bool
+	udpServer  bool
+}
+
+func (tl *testLayout) setup(t *testing.T) (server *chserver.Server, client *chclient.Client, teardown func()) {
+	//start of the world
+	// goroutines := runtime.NumGoroutine()
+	//root cancel
+	ctx, cancel := context.WithCancel(context.Background())
+	//fileserver (fake endpoint)
+	filePort := availablePort()
+	if tl.fileServer {
+		fileAddr := "127.0.0.1:" + filePort
+		f := http.Server{
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				b, _ := io.ReadAll(r.Body)
+				w.Write(append(b, '!'))
+			}),
+		}
+		fl, err := net.Listen("tcp", fileAddr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		log.Printf("fileserver: listening on %s", fileAddr)
+		go func() {
+			f.Serve(fl)
+			cancel()
+		}()
+		go func() {
+			<-ctx.Done()
+			f.Close()
+		}()
+	}
+	//server
+	server, err := chserver.NewServer(tl.server)
+	if err != nil {
+		t.Fatal(err)
+	}
+	server.Debug = debug
+	port := availablePort()
+	if err := server.StartContext(ctx, "127.0.0.1", port); err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		server.Wait()
+		server.Infof("Closed")
+		cancel()
+	}()
+	//client (with defaults)
+	tl.client.Fingerprint = server.GetFingerprint()
+	if tl.server.TLS.Key != "" {
+		//the domain name has to be localhost to match the ssl cert
+		tl.client.Server = "https://localhost:" + port
+	} else {
+		tl.client.Server = "http://127.0.0.1:" + port
+	}
+	for i, r := range tl.client.Remotes {
+		//convert $FILEPORT into the allocated port for this test case
+		if tl.fileServer {
+			tl.client.Remotes[i] = strings.Replace(r, "$FILEPORT", filePort, 1)
+		}
+	}
+	client, err = chclient.NewClient(tl.client)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.Debug = debug
+	if err := client.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		client.Wait()
+		client.Infof("Closed")
+		cancel()
+	}()
+	//cancel context tree, and wait for both client and server to stop
+	teardown = func() {
+		cancel()
+		server.Wait()
+		client.Wait()
+		//confirm goroutines have been cleaned up
+		// time.Sleep(500 * time.Millisecond)
+		// TODO remove sleep
+		// d := runtime.NumGoroutine() - goroutines
+		// if d != 0 {
+		// 	pprof.Lookup("goroutine").WriteTo(os.Stdout, 1)
+		// 	t.Fatalf("goroutines left %d", d)
+		// }
+	}
+	//wait a bit...
+	//TODO: client signal API, similar to os.Notify(signal)
+	//      wait for client setup
+	time.Sleep(50 * time.Millisecond)
+	//ready
+	return server, client, teardown
+}
+
+func simpleSetup(t *testing.T, s *chserver.Config, c *chclient.Config) context.CancelFunc {
+	s.Reverse = true
+	conf := testLayout{
+		server:     s,
+		client:     c,
+		fileServer: true,
+	}
+	_, _, teardown := conf.setup(t)
+	return teardown
+}
+
+func post(url, body string) (string, error) {
+	resp, err := http.Post(url, "text/plain", strings.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func postWithTls(url, body string, tlsConfig *tlsConfig) (string, error) {
+	caCertPool := x509.NewCertPool()
+	caCertPool.AppendCertsFromPEM([]byte(tlsConfig.clientTLS.Cert))
+
+	// Load the client certificate and key
+	clientCert, err := tls.LoadX509KeyPair(tlsConfig.clientTLS.Cert, tlsConfig.clientTLS.Key)
+	if err != nil {
+		return "", err
+	}
+
+	t := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			//Certificates: []tls.Certificate{},
+			RootCAs:            caCertPool,
+			Certificates:       []tls.Certificate{clientCert},
+			InsecureSkipVerify: true,
+		},
+	}
+
+	client := http.Client{Transport: t, Timeout: 15 * time.Second}
+	resp, err := client.Post(url, "text/plain", strings.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func availablePort() string {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		log.Panic(err)
+	}
+	l.Close()
+	_, port, err := net.SplitHostPort(l.Addr().String())
+	if err != nil {
+		log.Panic(err)
+	}
+	return port
+}

--- a/test/e2e/tls_test.go
+++ b/test/e2e/tls_test.go
@@ -1,0 +1,99 @@
+package e2e_test
+
+import (
+	"path"
+	"testing"
+
+	chclient "github.com/NextChapterSoftware/chissl/client"
+	chserver "github.com/NextChapterSoftware/chissl/server"
+)
+
+func TestMTLS(t *testing.T) {
+	tlsConfig, err := newTestTLSConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tlsConfig.Close()
+	//provide no client cert, server should reject the client request
+	tlsConfig.serverTLS.CA = path.Dir(tlsConfig.serverTLS.CA)
+
+	tmpPort := availablePort()
+	//setup server, client, fileserver
+	teardown := simpleSetup(t,
+		&chserver.Config{
+			TLS: *tlsConfig.serverTLS,
+		},
+		&chclient.Config{
+			Remotes: []string{tmpPort + ":127.0.0.1->$FILEPORT"},
+			TLS:     *tlsConfig.clientTLS,
+			Server:  "https://localhost:" + tmpPort,
+		})
+	defer teardown()
+	//test remote
+	result, err := postWithTls("https://localhost:"+tmpPort, "foo", tlsConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != "foo!" {
+		t.Fatalf("expected exclamation mark added")
+	}
+}
+
+func TestTLSMissingClientCert(t *testing.T) {
+	tlsConfig, err := newTestTLSConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tlsConfig.Close()
+	//provide no client cert, server should reject the client request
+	tlsConfig.clientTLS.Cert = ""
+	tlsConfig.clientTLS.Key = ""
+
+	tmpPort := availablePort()
+	//setup server, client, fileserver
+	teardown := simpleSetup(t,
+		&chserver.Config{
+			TLS: *tlsConfig.serverTLS,
+		},
+		&chclient.Config{
+			Remotes: []string{tmpPort + ":127.0.0.1->$FILEPORT"},
+			TLS:     *tlsConfig.clientTLS,
+			Server:  "https://localhost:" + tmpPort,
+		})
+	defer teardown()
+	//test remote
+	_, err = post("http://localhost:"+tmpPort, "foo")
+	if err == nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTLSMissingClientCA(t *testing.T) {
+	tlsConfig, err := newTestTLSConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tlsConfig.Close()
+	//specify a CA which does not match the client cert
+	//server should reject the client request
+	//provide no client cert, server should reject the client request
+	tlsConfig.serverTLS.CA = tlsConfig.clientTLS.CA
+
+	tmpPort := availablePort()
+	//setup server, client, fileserver
+	teardown := simpleSetup(t,
+		&chserver.Config{
+			TLS: *tlsConfig.serverTLS,
+		},
+		&chclient.Config{
+			Remotes: []string{tmpPort + ":127.0.0.1->$FILEPORT"},
+			TLS:     *tlsConfig.clientTLS,
+			Server:  "https://localhost:" + tmpPort,
+		})
+	defer teardown()
+	//test remote
+	_, err = post("http://localhost:"+tmpPort, "foo")
+	if err == nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
- Added rest API to list, create, update and delete users (Uses Admin users' password for basic auth)
- Added api to submit (update)  an entire authfile
- Brought back e2e tests
- Fixed a port assignment issue in the client